### PR TITLE
Fix asset mapping property names in template stamper

### DIFF
--- a/functions/src/template-stamper/jobs/triggerRender.ts
+++ b/functions/src/template-stamper/jobs/triggerRender.ts
@@ -155,9 +155,10 @@ async function prepareInputProps(
   const props: Record<string, any> = {};
 
   for (const mapping of assetMappings) {
-    const slot = template.slots.find((s: any) => s.id === mapping.slotId);
+    const slot = template.slots.find((s: any) => s.slotId === mapping.slotId);
     if (slot) {
-      props[slot.id] = mapping.assetUrl;
+      // For text slots use textValue, for file slots use storageUrl
+      props[slot.slotId] = mapping.type === 'text' ? mapping.textValue : mapping.storageUrl;
     }
   }
 
@@ -176,11 +177,11 @@ async function generateSignedUrls(
 
   for (const mapping of assetMappings) {
     // Skip if not a Cloud Storage URL (e.g., text values or direct URLs)
-    if (!mapping.assetUrl || !mapping.assetUrl.startsWith('gs://')) {
+    if (!mapping.storageUrl || !mapping.storageUrl.startsWith('gs://')) {
       continue;
     }
 
-    const filePath = mapping.assetUrl.replace('gs://' + bucket.name + '/', '');
+    const filePath = mapping.storageUrl.replace('gs://' + bucket.name + '/', '');
     const file = bucket.file(filePath);
 
     const [url] = await file.getSignedUrl({


### PR DESCRIPTION
## Summary
Fixed incorrect property name references in the asset mapping logic for the template stamper. The changes align property access with the actual data structure being used.

## Key Changes
- Updated slot property reference from `s.id` to `s.slotId` when finding slots in template
- Changed asset mapping property from `assetUrl` to `storageUrl` for Cloud Storage URLs
- Updated props assignment to use `slot.slotId` instead of `slot.id`
- Enhanced props assignment logic to differentiate between text and file slot types:
  - Text slots now use `mapping.textValue`
  - File slots now use `mapping.storageUrl`
- Updated signed URL generation to reference `mapping.storageUrl` instead of `mapping.assetUrl`

## Implementation Details
The changes ensure that the code correctly accesses properties on the slot and asset mapping objects. The enhanced logic in `prepareInputProps` now properly handles different mapping types, allowing text values to be passed directly while file-based assets use their storage URLs.

https://claude.ai/code/session_011fVqYcC6VamMskQU8wncbj