### PR TITLE
agent-collective-v2: session-aware download endpoints (closes #6)

### DIFF
--- a/public/agent-collective-v2/script.js
+++ b/public/agent-collective-v2/script.js
@@ -619,24 +619,31 @@ async function sendWithUpload(file, text, phaseIndicatorEl) {
 // Download collection helper
 // =========================================================================
 
+// Append ?session_id=<sid> so the server returns the file written by THIS
+// session, not whichever session most recently finished in the same market
+// (issue #6).
+function withSession(url) {
+  return sessionId ? `${url}?session_id=${encodeURIComponent(sessionId)}` : url;
+}
+
 function collectDownload(fnName, pendingDownloads) {
   if (fnName === "save_marketing_brief_artifact") {
-    pendingDownloads.push({ href: `${API_BASE}/api/brief`, artifact: "marketing_brief.json", filename: "marketing_brief.md", label: "Download marketing brief" });
+    pendingDownloads.push({ href: withSession(`${API_BASE}/api/brief`), artifact: "marketing_brief.json", filename: "marketing_brief.md", label: "Download marketing brief" });
   }
   if (fnName === "save_creative_package_artifact") {
-    pendingDownloads.push({ href: `${API_BASE}/api/creative-package`, artifact: "creative_package.md", filename: "creative_package.md", label: "Download creative package" });
+    pendingDownloads.push({ href: withSession(`${API_BASE}/api/creative-package`), artifact: "creative_package.md", filename: "creative_package.md", label: "Download creative package" });
   }
   if (fnName === "save_generation_manifest_artifact") {
-    pendingDownloads.push({ href: `${API_BASE}/api/manifest`, artifact: "generation_manifest.json", filename: "generation_manifest.json", label: "Download generation manifest" });
+    pendingDownloads.push({ href: withSession(`${API_BASE}/api/manifest`), artifact: "generation_manifest.json", filename: "generation_manifest.json", label: "Download generation manifest" });
     enableMcpBridge();
   }
   if (fnName === "save_variation_artifact") {
-    pendingDownloads.push({ href: `${API_BASE}/api/creative-package`, artifact: "creative_package.md", filename: "creative_package.md", label: "Download creative package" });
-    pendingDownloads.push({ href: `${API_BASE}/api/manifest`, artifact: "generation_manifest.json", filename: "generation_manifest.json", label: "Download generation manifest" });
+    pendingDownloads.push({ href: withSession(`${API_BASE}/api/creative-package`), artifact: "creative_package.md", filename: "creative_package.md", label: "Download creative package" });
+    pendingDownloads.push({ href: withSession(`${API_BASE}/api/manifest`), artifact: "generation_manifest.json", filename: "generation_manifest.json", label: "Download generation manifest" });
     enableMcpBridge();
   }
   if (fnName === "save_full_campaign_manifest_artifact") {
-    pendingDownloads.push({ href: `${API_BASE}/api/full-campaign-manifest`, artifact: "full_campaign_manifest.json", filename: "full_campaign_manifest.json", label: "Download full campaign manifest" });
+    pendingDownloads.push({ href: withSession(`${API_BASE}/api/full-campaign-manifest`), artifact: "full_campaign_manifest.json", filename: "full_campaign_manifest.json", label: "Download full campaign manifest" });
     enableMcpBridge();
   }
 }
@@ -989,16 +996,16 @@ mcpSendBtn.addEventListener("click", async () => {
   mcpSendBtn.disabled = true;
   mcpHint.textContent = "Sending...";
   try {
-    // Fetch manifest
-    let manifestResp = await fetch(`${API_BASE}/api/full-campaign-manifest`);
-    if (!manifestResp.ok) manifestResp = await fetch(`${API_BASE}/api/manifest`);
+    // Fetch manifest (session-keyed so concurrent sessions can't race; see issue #6)
+    let manifestResp = await fetch(withSession(`${API_BASE}/api/full-campaign-manifest`));
+    if (!manifestResp.ok) manifestResp = await fetch(withSession(`${API_BASE}/api/manifest`));
     if (!manifestResp.ok) { showToast("No manifest available"); mcpSendBtn.disabled = false; return; }
     const manifestData = await manifestResp.json();
 
     // Fetch creative package (optional — don't block if unavailable)
     let creativePackage = null;
     try {
-      const cpResp = await fetch(`${API_BASE}/api/creative-package`);
+      const cpResp = await fetch(withSession(`${API_BASE}/api/creative-package`));
       if (cpResp.ok) creativePackage = await cpResp.text();
     } catch {}
 

--- a/services/agent-collective-v2/agent_collective/agent.py
+++ b/services/agent-collective-v2/agent_collective/agent.py
@@ -137,6 +137,7 @@ def _get_run_dir(session_id: str) -> Path:
 
     today = datetime.now().strftime("%Y-%m-%d")
     MARKET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    _prune_stale_session_latests()
     existing = sorted(MARKET_OUTPUT_DIR.glob(f"run_{today}_*"))
     next_num = len(existing) + 1
     run_dir = MARKET_OUTPUT_DIR / f"run_{today}_{next_num:03d}"
@@ -166,6 +167,115 @@ def _release_session_tracking(session_id: str):
     _run_start_times.pop(session_id, None)
     _agent_timings.pop(session_id, None)
     _agent_start_times.pop(session_id, None)
+
+
+# =========================================================================
+# Session-keyed latest_* files (issue #6)
+# =========================================================================
+# The MARKET_OUTPUT_DIR / "latest_*.{md,json}" files are overwritten by every
+# pipeline run, so concurrent sessions in the same market race on download.
+# We additionally write a session-keyed copy (latest_*_{sid}.{ext}) so the
+# download endpoints can serve the file belonging to the requesting session.
+# Market-level latest_* files are kept as a fallback for callers without a sid.
+#
+# Pruning: stale session-keyed copies (> _SESSION_LATEST_TTL seconds) are
+# removed opportunistically when a new run folder is created. No background
+# cron required.
+
+_SESSION_LATEST_TTL = 24 * 3600  # 24 hours
+
+_SAFE_SID_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _safe_sid(session_id: str) -> str:
+    """Make a session_id safe for use in a filename."""
+    return _SAFE_SID_RE.sub("_", session_id)[:64]
+
+
+def _session_keyed_path(base_name: str, session_id: str) -> Path:
+    """Return MARKET_OUTPUT_DIR / latest_<stem>_<sid><suffix>.
+
+    Example: ("latest_generation_manifest.json", "abc-123") ->
+    MARKET_OUTPUT_DIR / "latest_generation_manifest_abc-123.json"
+    """
+    p = Path(base_name)
+    return MARKET_OUTPUT_DIR / f"{p.stem}_{_safe_sid(session_id)}{p.suffix}"
+
+
+def _write_market_latest(
+    base_name: str,
+    content,
+    session_id: str | None = None,
+    *,
+    is_json: bool = False,
+):
+    """Write a latest_* file at the market level and (if sid given) a
+    session-keyed sibling. Both copies are kept in sync so callers without
+    a session_id continue to get the most recent run.
+    """
+    MARKET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    targets = [MARKET_OUTPUT_DIR / base_name]
+    if session_id:
+        targets.append(_session_keyed_path(base_name, session_id))
+    for path in targets:
+        if is_json:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(content, f, indent=2, ensure_ascii=False)
+        else:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+
+_LATEST_BASE_NAMES = (
+    "latest_marketing_brief.md",
+    "latest_creative_package.md",
+    "latest_generation_manifest.json",
+    "latest_full_campaign_manifest.json",
+)
+
+
+def _is_session_keyed_latest(path: Path) -> bool:
+    """True if path is a session-keyed latest_* sibling (not the market-level
+    latest_<base>.<ext> file itself).
+    """
+    name = path.name
+    for base in _LATEST_BASE_NAMES:
+        if name == base:
+            return False
+        base_p = Path(base)
+        prefix = f"{base_p.stem}_"
+        if name.startswith(prefix) and name.endswith(base_p.suffix):
+            sid = name[len(prefix):-len(base_p.suffix)]
+            if sid:  # non-empty sid component
+                return True
+    return False
+
+
+def _prune_stale_session_latests(now_ts: float | None = None):
+    """Remove latest_*_<sid>.{md,json} files older than _SESSION_LATEST_TTL.
+
+    Best-effort; failures are swallowed so a permission glitch never blocks
+    a new pipeline run. Only files matching the session-keyed pattern for
+    one of the four known latest_* base names are eligible for deletion.
+    """
+    if not MARKET_OUTPUT_DIR.exists():
+        return
+    if now_ts is None:
+        now_ts = datetime.now().timestamp()
+    cutoff = now_ts - _SESSION_LATEST_TTL
+    try:
+        for path in MARKET_OUTPUT_DIR.iterdir():
+            if not path.is_file():
+                continue
+            if not _is_session_keyed_latest(path):
+                continue
+            try:
+                if path.stat().st_mtime < cutoff:
+                    path.unlink()
+            except OSError:
+                continue
+    except Exception:
+        pass
 
 
 def _parse_state_value(value):
@@ -714,9 +824,7 @@ def _make_latest_brief_markdown_callback():
 
         with open(run_dir / "latest_marketing_brief.md", "w", encoding="utf-8") as f:
             f.write(md_content)
-        MARKET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-        with open(MARKET_OUTPUT_DIR / "latest_marketing_brief.md", "w", encoding="utf-8") as f:
-            f.write(md_content)
+        _write_market_latest("latest_marketing_brief.md", md_content, sid)
 
         _record_agent_timing(sid, "brief_presenter")
 
@@ -750,24 +858,23 @@ async def _session_state_export_callback(callback_context):
         json.dump(export, f, indent=2, ensure_ascii=False)
 
     # Keep market-scoped latest files current for the download endpoints.
-    MARKET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-
+    # Each call also writes a session-keyed sibling so concurrent sessions
+    # in the same market don't race on download (see issue #6).
     brief = export.get("marketing_brief")
     if brief is not None:
         md_content = _marketing_brief_to_markdown(brief)
-        with open(MARKET_OUTPUT_DIR / "latest_marketing_brief.md", "w", encoding="utf-8") as f:
-            f.write(md_content)
+        _write_market_latest("latest_marketing_brief.md", md_content, sid)
 
     manifest = export.get("generation_manifest")
     if manifest is not None:
-        with open(MARKET_OUTPUT_DIR / "latest_generation_manifest.json", "w", encoding="utf-8") as f:
-            json.dump(manifest, f, indent=2, ensure_ascii=False)
+        _write_market_latest(
+            "latest_generation_manifest.json", manifest, sid, is_json=True,
+        )
 
     creative = export.get("creative_package")
     if creative is not None:
         md_content = _creative_package_to_markdown(creative)
-        with open(MARKET_OUTPUT_DIR / "latest_creative_package.md", "w", encoding="utf-8") as f:
-            f.write(md_content)
+        _write_market_latest("latest_creative_package.md", md_content, sid)
 
     _record_agent_timing(sid, "results_presenter")
     _write_run_timing(sid, run_dir)
@@ -1652,8 +1759,6 @@ async def _adaptation_session_state_export_callback(callback_context):
     with open(session_path, "w", encoding="utf-8") as f:
         json.dump(export, f, indent=2, ensure_ascii=False)
 
-    MARKET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-
     manifest = _build_adaptation_manifest(export)
 
     # Fallback: if the primary variation_output couldn't be parsed (e.g. the
@@ -1685,8 +1790,9 @@ async def _adaptation_session_state_export_callback(callback_context):
             json.dump(manifest, f, indent=2, ensure_ascii=False)
         with open(run_dir / "latest_generation_manifest.json", "w", encoding="utf-8") as f:
             json.dump(manifest, f, indent=2, ensure_ascii=False)
-        with open(MARKET_OUTPUT_DIR / "latest_generation_manifest.json", "w", encoding="utf-8") as f:
-            json.dump(manifest, f, indent=2, ensure_ascii=False)
+        _write_market_latest(
+            "latest_generation_manifest.json", manifest, sid, is_json=True,
+        )
 
     md_content = _build_adaptation_package_md(export)
     if md_content:
@@ -1694,8 +1800,7 @@ async def _adaptation_session_state_export_callback(callback_context):
             f.write(md_content)
         with open(run_dir / "latest_creative_package.md", "w", encoding="utf-8") as f:
             f.write(md_content)
-        with open(MARKET_OUTPUT_DIR / "latest_creative_package.md", "w", encoding="utf-8") as f:
-            f.write(md_content)
+        _write_market_latest("latest_creative_package.md", md_content, sid)
 
     _record_agent_timing(sid, "adapt_results_presenter")
     _write_run_timing(sid, run_dir)
@@ -2614,9 +2719,9 @@ async def _fc_session_state_export_callback(callback_context):
             json.dump(manifest, f, indent=2, ensure_ascii=False)
         with open(run_dir / "full_campaign_manifest.json", "w", encoding="utf-8") as f:
             json.dump(manifest, f, indent=2, ensure_ascii=False)
-        MARKET_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-        with open(MARKET_OUTPUT_DIR / "latest_full_campaign_manifest.json", "w", encoding="utf-8") as f:
-            json.dump(manifest, f, indent=2, ensure_ascii=False)
+        _write_market_latest(
+            "latest_full_campaign_manifest.json", manifest, sid, is_json=True,
+        )
 
     _record_agent_timing(sid, "fc_results_presenter")
     _write_run_timing(sid, run_dir)

--- a/services/agent-collective-v2/demo_ui/server.py
+++ b/services/agent-collective-v2/demo_ui/server.py
@@ -19,10 +19,12 @@ Endpoints:
     POST /api/run                    - Blocking fallback
     POST /api/run/upload             - File upload + SSE stream
     GET  /api/artifact/{sid}/{name}  - Download an artifact from the session
-    GET  /api/brief                  - Download latest marketing brief
-    GET  /api/creative-package       - Download latest creative package
-    GET  /api/manifest               - Download latest generation manifest
-    GET  /api/full-campaign-manifest - Download latest full campaign manifest
+    GET  /api/brief?session_id=<sid>                  - Download latest marketing brief
+    GET  /api/creative-package?session_id=<sid>       - Download latest creative package
+    GET  /api/manifest?session_id=<sid>               - Download latest generation manifest
+    GET  /api/full-campaign-manifest?session_id=<sid> - Download latest full campaign manifest
+    (session_id is optional; without it, the market-level latest_* file is served — may
+     reflect a different session if multiple ran concurrently in the same market)
     GET  /api/kb                     - List KB files
     GET  /api/kb/file                - Read a KB file
     POST /api/kb/upload              - Upload a KB file
@@ -340,9 +342,26 @@ async def get_artifact(session_id: str, artifact_name: str):
 # File download endpoints (latest outputs from agent callbacks)
 # -------------------------------------------------------------------------
 
+# Resolve a download to the session-keyed copy when ?session_id=<sid> is
+# given. Falls back to the market-level latest_* file (which reflects whichever
+# session most recently finished) so legacy callers keep working. See issue #6.
+_SAFE_SID_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _resolve_latest(base_name: str, session_id: str | None) -> Path:
+    """Return path to the latest_* file, preferring the session-keyed copy."""
+    if session_id:
+        safe = _SAFE_SID_RE.sub("_", session_id)[:64]
+        p = Path(base_name)
+        keyed = OUTPUTS_DIR / f"{p.stem}_{safe}{p.suffix}"
+        if keyed.exists():
+            return keyed
+    return OUTPUTS_DIR / base_name
+
+
 @app.get("/api/brief")
-async def get_brief():
-    path = OUTPUTS_DIR / "latest_marketing_brief.md"
+async def get_brief(session_id: str | None = None):
+    path = _resolve_latest("latest_marketing_brief.md", session_id)
     if not path.exists():
         raise HTTPException(status_code=404, detail="No marketing brief found.")
     return Response(
@@ -353,8 +372,8 @@ async def get_brief():
 
 
 @app.get("/api/creative-package")
-async def get_creative_package():
-    path = OUTPUTS_DIR / "latest_creative_package.md"
+async def get_creative_package(session_id: str | None = None):
+    path = _resolve_latest("latest_creative_package.md", session_id)
     if not path.exists():
         raise HTTPException(status_code=404, detail="No creative package found.")
     return Response(
@@ -365,8 +384,8 @@ async def get_creative_package():
 
 
 @app.get("/api/manifest")
-async def get_manifest():
-    path = OUTPUTS_DIR / "latest_generation_manifest.json"
+async def get_manifest(session_id: str | None = None):
+    path = _resolve_latest("latest_generation_manifest.json", session_id)
     if not path.exists():
         raise HTTPException(status_code=404, detail="No generation manifest found.")
     return Response(
@@ -377,8 +396,8 @@ async def get_manifest():
 
 
 @app.get("/api/full-campaign-manifest")
-async def get_full_campaign_manifest():
-    path = OUTPUTS_DIR / "latest_full_campaign_manifest.json"
+async def get_full_campaign_manifest(session_id: str | None = None):
+    path = _resolve_latest("latest_full_campaign_manifest.json", session_id)
     if not path.exists():
         raise HTTPException(status_code=404, detail="No full campaign manifest found.")
     return Response(


### PR DESCRIPTION
## Summary
- Adds `?session_id=<sid>` to the four `/api/{brief,creative-package,manifest,full-campaign-manifest}` endpoints so concurrent sessions in the same market don't race on the shared `latest_*` files.
- `agent.py` now writes a session-keyed sibling (`latest_<base>_<sid>.<ext>`) alongside each market-level `latest_*` write. The market-level files are kept as a fallback for callers without a session ID, so no integration breaks.
- Frontend (`script.js`) passes the active session ID on all six download URLs via a `withSession` helper, including the MCP send-to-generator handler.
- Stale session-keyed copies are pruned (TTL 24h) on each new pipeline start. Prune is scoped strictly to files matching `latest_<known-base>_<sid>.<ext>` so the four market-level files are never deleted by mistake.

Closes #6.

## Test plan
- [ ] Run a single pipeline; confirm `latest_*_<sid>.<ext>` files appear in `outputs/{market}/` alongside the market-level `latest_*` files.
- [ ] Hit `/api/manifest?session_id=<sid>` directly; confirm 200 with the session's manifest content.
- [ ] Hit `/api/manifest` (no sid); confirm 200 with the most recent market-level manifest (fallback path).
- [ ] Run two pipelines concurrently in the same market; confirm each frontend's "Send to Generator" sends its own manifest, not the other's.
- [ ] Touch a `latest_*_<sid>.<ext>` file's mtime to >24h ago, start a new pipeline, confirm it's pruned. Confirm the four market-level `latest_*.{md,json}` files are NOT pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)