### PR TITLE
feat: veo_shorts_v1 template integration in agent collective

### DIFF
--- a/docs/superpowers/plans/2026-05-06-template-integration.md
+++ b/docs/superpowers/plans/2026-05-06-template-integration.md
@@ -1,0 +1,517 @@
+# Template Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a Photo to Video concept reaches the creative phase, agent collective constrains the storyboard to the veo_shorts_v1 template structure, surfaces the template to the user, and embeds slot IDs in the generation manifest so the creative generator can produce the correct template stamper handoff.
+
+**Architecture:** A `TEMPLATE_CATALOG` dict in `agent.py` maps feature names to template schemas. A `before_agent_callback` on `creative_phase` looks up the active featured tool and writes the matching schema to session state. Three prompt files read `template_schema` from session state via template injection and adapt their output accordingly.
+
+**Tech Stack:** Python 3.12, Google ADK (`google-adk==1.28.0`), pytest, Markdown prompt files injected via `{template_schema}` state substitution.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `services/agent-collective-v2/agent_collective/agent.py` | Add `TEMPLATE_CATALOG` constant; add `_make_creative_phase_before_callback()`; wire callback to `creative_phase` |
+| `services/agent-collective-v2/agent_collective/prompts/creative/creative_director.md` | Change camera roll count 6→9; add template-aware selected photo section |
+| `services/agent-collective-v2/agent_collective/prompts/creative/creative_presenter.md` | Surface template name when template_schema is present |
+| `services/agent-collective-v2/agent_collective/prompts/production/creative_prompter.md` | Add template_id/slot_id/selected_slot_mapping to manifest output schema |
+| `services/agent-collective-v2/tests/test_template_catalog.py` | New — unit tests for catalog lookup and callback state-writing logic |
+
+---
+
+## Task 1: Add TEMPLATE_CATALOG and creative_phase callback to agent.py
+
+**Files:**
+- Modify: `services/agent-collective-v2/agent_collective/agent.py`
+- Create: `services/agent-collective-v2/tests/test_template_catalog.py`
+
+- [ ] **Step 1: Create test file and write failing tests**
+
+Create `services/agent-collective-v2/tests/__init__.py` (empty) and `services/agent-collective-v2/tests/test_template_catalog.py`:
+
+```python
+import json
+import pytest
+import sys
+from pathlib import Path
+
+# Allow importing agent_collective without a full ADK environment
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so agent.py can be imported without google-adk installed
+# in the test environment. If google-adk IS installed these are ignored.
+# ---------------------------------------------------------------------------
+try:
+    from agent_collective.agent import TEMPLATE_CATALOG, _make_creative_phase_before_callback
+except ImportError:
+    pytest.skip("google-adk not available", allow_module_level=True)
+
+
+class _FakeState(dict):
+    pass
+
+
+class _FakeSession:
+    id = "test-session"
+
+
+class _FakeCallbackContext:
+    def __init__(self, state: dict):
+        self.state = _FakeState(state)
+        self.session = _FakeSession()
+
+
+# ---------------------------------------------------------------------------
+# TEMPLATE_CATALOG tests
+# ---------------------------------------------------------------------------
+
+def test_catalog_has_photo_to_video():
+    assert "Photo to Video" in TEMPLATE_CATALOG
+
+
+def test_photo_to_video_maps_to_veo_shorts_v1():
+    entry = TEMPLATE_CATALOG["Photo to Video"]
+    assert entry["template_id"] == "veo_shorts_v1"
+    assert entry["template_version"] == "1.0"
+
+
+def test_photo_to_video_has_selected_image_count_2():
+    assert TEMPLATE_CATALOG["Photo to Video"]["selected_image_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _make_creative_phase_before_callback tests
+# ---------------------------------------------------------------------------
+
+def _make_brief(feature_name: str) -> str:
+    return json.dumps({
+        "proposition": {
+            "featured_tool": {
+                "feature_name": feature_name
+            }
+        }
+    })
+
+
+@pytest.mark.asyncio
+async def test_callback_writes_template_schema_for_photo_to_video():
+    ctx = _FakeCallbackContext({"marketing_brief": _make_brief("Photo to Video")})
+    cb = _make_creative_phase_before_callback()
+    await cb(ctx)
+    assert ctx.state.get("template_schema") is not None
+    schema = json.loads(ctx.state["template_schema"])
+    assert schema["template_id"] == "veo_shorts_v1"
+    assert schema["selected_image_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_callback_writes_none_for_unknown_tool():
+    ctx = _FakeCallbackContext({"marketing_brief": _make_brief("Add Audio")})
+    cb = _make_creative_phase_before_callback()
+    await cb(ctx)
+    assert ctx.state.get("template_schema") is None
+
+
+@pytest.mark.asyncio
+async def test_callback_handles_missing_brief_gracefully():
+    ctx = _FakeCallbackContext({})
+    cb = _make_creative_phase_before_callback()
+    await cb(ctx)  # must not raise
+    assert ctx.state.get("template_schema") is None
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd services/agent-collective-v2
+.venv/bin/pytest tests/test_template_catalog.py -v 2>&1 | head -30
+```
+
+Expected: `ImportError` or `FAILED` — `TEMPLATE_CATALOG` and `_make_creative_phase_before_callback` don't exist yet.
+
+- [ ] **Step 3: Add TEMPLATE_CATALOG to agent.py**
+
+In `agent_collective/agent.py`, after the `MARKET_OUTPUT_DIR` and `KB_CACHE_DIR` lines (around line 57), add:
+
+```python
+# =========================================================================
+# Template catalog
+# =========================================================================
+# Maps Shorts Creation Tool feature_name → Remotion template schema.
+# 1:1 for now. Extend to a list per key when multiple templates exist per tool.
+
+TEMPLATE_CATALOG: dict[str, dict] = {
+    "Photo to Video": {
+        "template_id": "veo_shorts_v1",
+        "template_version": "1.0",
+        "selected_image_count": 2,
+        "has_generated_video": True,
+        "has_prompt_text": True,
+    },
+}
+```
+
+- [ ] **Step 4: Add _make_creative_phase_before_callback to agent.py**
+
+In `agent_collective/agent.py`, add this function in the callbacks section (after `_make_timing_before_callback`, around line 578):
+
+```python
+def _make_creative_phase_before_callback():
+    """Before-callback for creative_phase.
+
+    Reads marketing_brief from session state, looks up the featured tool in
+    TEMPLATE_CATALOG, and writes the matching template schema (or None) as
+    template_schema to session state. All downstream prompt conditionals gate
+    on this key.
+    """
+    async def callback(callback_context) -> None:
+        brief_raw = callback_context.state.get("marketing_brief")
+        if not brief_raw:
+            callback_context.state["template_schema"] = None
+            return
+        brief = _parse_state_value(brief_raw)
+        feature_name = (
+            brief.get("proposition", {})
+                 .get("featured_tool", {})
+                 .get("feature_name", "")
+        ) or ""
+        template = TEMPLATE_CATALOG.get(feature_name)
+        callback_context.state["template_schema"] = (
+            json.dumps(template) if template else None
+        )
+    return callback
+```
+
+- [ ] **Step 5: Wire callback to creative_phase**
+
+Find the `creative_phase` SequentialAgent definition (around line 2036) and add the callback:
+
+```python
+creative_phase = SequentialAgent(
+    name="creative_phase",
+    sub_agents=[creative_director, creative_presenter],
+    before_agent_callback=_make_creative_phase_before_callback(),
+)
+```
+
+- [ ] **Step 6: Run tests — expect pass**
+
+```bash
+cd services/agent-collective-v2
+.venv/bin/pytest tests/test_template_catalog.py -v
+```
+
+Expected output:
+```
+tests/test_template_catalog.py::test_catalog_has_photo_to_video PASSED
+tests/test_template_catalog.py::test_photo_to_video_maps_to_veo_shorts_v1 PASSED
+tests/test_template_catalog.py::test_photo_to_video_has_selected_image_count_2 PASSED
+tests/test_template_catalog.py::test_callback_writes_template_schema_for_photo_to_video PASSED
+tests/test_template_catalog.py::test_callback_writes_none_for_unknown_tool PASSED
+tests/test_template_catalog.py::test_callback_handles_missing_brief_gracefully PASSED
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent_collective/agent.py tests/__init__.py tests/test_template_catalog.py
+git commit -m "feat: add TEMPLATE_CATALOG and creative_phase template detection callback"
+```
+
+---
+
+## Task 2: Update creative_director.md — camera roll 6→9 and selected photo markup
+
+**Files:**
+- Modify: `services/agent-collective-v2/agent_collective/prompts/creative/creative_director.md`
+
+- [ ] **Step 1: Change camera roll count from 6 to 9 (two occurrences)**
+
+In `creative_director.md` line 172, change:
+```
+"string | null - camera roll scenes always list exactly 6 photos (camera_roll_photo_01 through camera_roll_photo_06)"
+```
+to:
+```
+"string | null - camera roll scenes always list exactly 9 photos (camera_roll_photo_01 through camera_roll_photo_09)"
+```
+
+In `creative_director.md` line 222, change:
+```
+**Camera roll scenes always use exactly 6 nested images** (`camera_roll_photo_01` through `camera_roll_photo_06`) to match the locked UI template. List all 6 individually so each gets its own generation job. Do not use a different count.
+```
+to:
+```
+**Camera roll scenes always use exactly 9 nested images** (`camera_roll_photo_01` through `camera_roll_photo_09`) to match the locked UI template. List all 9 individually so each gets its own generation job. Do not use a different count.
+```
+
+- [ ] **Step 2: Add template-aware selected photo section**
+
+Append the following section to `creative_director.md` immediately before the `## ADK Integration Postscript` heading:
+
+```markdown
+## Template-aware storyboarding
+
+The session state key `template_schema` tells you whether the selected concept maps to a Remotion template. Check its value before designing the storyboard.
+
+Current value: `{template_schema}`
+
+If `template_schema` is not null, parse it and apply these additional rules:
+
+### Selected photos (Photo to Video template)
+
+When `template_schema.selected_image_count` is present (value: 2), you must designate exactly that many of the 9 camera roll photos as the **selected inputs** for AI video generation. The selection must be creatively motivated: choose the photos whose subjects would produce the most compelling and narratively coherent transformation.
+
+For each selected photo element, add two extra fields alongside the existing ones:
+
+```json
+{
+  "element_id": "camera_roll_photo_03",
+  "element_type": "ui_nested_asset",
+  "description": "...",
+  "creative_direction": "...",
+  "selected": true,
+  "selection_rationale": "This photo's subject — [brief reason] — will produce the strongest transformation payoff."
+}
+```
+
+Non-selected photos omit `selected` and `selection_rationale` entirely (do not set `selected: false`).
+
+The selection rationale is read by the creative_presenter to explain to the user why these two photos anchor the video generation.
+```
+
+- [ ] **Step 3: Verify the file looks right**
+
+```bash
+grep -n "camera_roll_photo_0\|selected_image\|template_schema\|Template-aware" services/agent-collective-v2/agent_collective/prompts/creative/creative_director.md
+```
+
+Expected: lines reference `camera_roll_photo_09`, `template_schema`, `selected_image_count`, `Template-aware storyboarding`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent_collective/prompts/creative/creative_director.md
+git commit -m "feat: update creative_director — 9 camera roll photos, template-aware selected photo markup"
+```
+
+---
+
+## Task 3: Update creative_presenter.md — surface template name
+
+**Files:**
+- Modify: `services/agent-collective-v2/agent_collective/prompts/creative/creative_presenter.md`
+
+- [ ] **Step 1: Add template surface to the opening context section**
+
+In `creative_presenter.md`, find the `### 1. Opening context (one line)` section and replace it with:
+
+```markdown
+### 1. Opening context
+
+If `template_schema` is not null (current value: `{template_schema}`), open with exactly this line before anything else:
+
+> "This concept will be produced using the **[template_schema.template_id]** template."
+
+Then on the next line, add the standard one-line campaign context (e.g., "Here are the creative concepts for the Korea campaign, ready for your review.").
+
+If `template_schema` is null, open with the standard one-line campaign context only.
+```
+
+- [ ] **Step 2: Add template_schema to the Session Data section**
+
+At the bottom of `creative_presenter.md`, append to the `## Session Data` section:
+
+```markdown
+### template_schema
+{template_schema}
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "template_schema\|template_id\|Session Data" services/agent-collective-v2/agent_collective/prompts/creative/creative_presenter.md
+```
+
+Expected: lines reference `template_schema` in the opening context rule and in Session Data.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent_collective/prompts/creative/creative_presenter.md
+git commit -m "feat: creative_presenter surfaces template name when template_schema is active"
+```
+
+---
+
+## Task 4: Update creative_prompter.md — slot IDs and template manifest fields
+
+**Files:**
+- Modify: `services/agent-collective-v2/agent_collective/prompts/production/creative_prompter.md`
+
+- [ ] **Step 1: Add template-aware manifest section**
+
+In `creative_prompter.md`, append the following section immediately before `## What to avoid`:
+
+```markdown
+## Template-aware manifest generation
+
+The session state key `template_schema` tells you whether this run maps to a Remotion template.
+
+Current value: `{template_schema}`
+
+If `template_schema` is not null, apply these additional rules when building the manifest:
+
+### Top-level template fields
+
+Add two fields at the root of the manifest object:
+
+```json
+{
+  "template_id": "<template_schema.template_id>",
+  "template_version": "<template_schema.template_version>",
+  ...
+}
+```
+
+### slot_id per job
+
+For every job, add a `slot_id` field. Set it according to these rules:
+
+- **Camera roll photos** (`element_type: "ui_nested_asset"`, `element_id` matching `camera_roll_photo_01` through `camera_roll_photo_09`): assign `slot_id` values `gridImage1` through `gridImage9` in the same order (photo_01 → gridImage1, photo_02 → gridImage2, … photo_09 → gridImage9).
+- **Veo payoff video** (the climax scene's video job, `asset_type: "video"` from a `hook`/`body`/`climax`/`resolution` scene that is not a camera roll photo): assign `slot_id: "generatedVideo"`.
+- **All other jobs**: assign `slot_id: null`.
+
+### selected_slot_mapping
+
+After the `jobs` array, add a `selected_slot_mapping` object. Read the creative_package storyboard and find the 2 camera roll photos that have `"selected": true`. Map their template slot IDs to their job IDs:
+
+```json
+"selected_slot_mapping": {
+  "selectedImage1": "job_003",
+  "selectedImage2": "job_007"
+}
+```
+
+Where `job_003` and `job_007` are the `job_id` values of the two selected camera roll photo jobs. The order is the order the selected photos appear in the storyboard element list.
+
+If `template_schema` is null, omit `template_id`, `template_version`, and `selected_slot_mapping` from the manifest entirely, and set `slot_id: null` on all jobs.
+```
+
+- [ ] **Step 2: Update the Output Schema section to include the new fields**
+
+In the `## Output Schema` section of `creative_prompter.md`, find the opening of the JSON schema block and add the two new optional top-level fields and the `selected_slot_mapping` field:
+
+```json
+{
+  "manifest_version": "1.1",
+  "brief_id": "string - carried from marketing_brief.brief_id",
+  "brief_name": "string - carried from marketing_brief.brief_name",
+  "market": "string - country code from marketing_brief.market.country_code",
+  "market_nationality": "string - carried from marketing_brief.market.market_nationality",
+  "created_at": "ISO 8601 timestamp",
+  "template_id": "string | null - veo_shorts_v1 when template active, else omit",
+  "template_version": "string | null - e.g. 1.0 when template active, else omit",
+  "total_reference_images": 0,
+  "total_jobs": 0,
+  "total_text_items": 0,
+  "reference_images": [ ... ],
+  "jobs": [
+    {
+      "job_id": "string - e.g. job_001",
+      "slot_id": "string | null - e.g. gridImage1, generatedVideo, or null",
+      ...
+    }
+  ],
+  "selected_slot_mapping": {
+    "selectedImage1": "string - job_id of the first selected camera roll photo",
+    "selectedImage2": "string - job_id of the second selected camera roll photo"
+  },
+  "text_items": [ ... ]
+}
+```
+
+(Leave all existing fields in `reference_images`, `jobs`, and `text_items` unchanged. Only add `template_id`, `template_version`, `slot_id` on jobs, and `selected_slot_mapping`.)
+
+- [ ] **Step 3: Add template_schema to the Session Data section**
+
+At the bottom of `creative_prompter.md`, append to the `## Session Data` section:
+
+```markdown
+### template_schema
+{template_schema}
+```
+
+- [ ] **Step 4: Update the ADK Integration Postscript State reads**
+
+In the `## ADK Integration Postscript` section, find the `**State reads:**` list and add:
+
+```
+- `template_schema` - Template schema if active featured tool maps to a Remotion template, else null
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+grep -n "template_schema\|template_id\|template_version\|slot_id\|selected_slot_mapping\|gridImage\|generatedVideo" services/agent-collective-v2/agent_collective/prompts/production/creative_prompter.md
+```
+
+Expected: multiple hits across the new section, schema block, and Session Data.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent_collective/prompts/production/creative_prompter.md
+git commit -m "feat: creative_prompter emits template_id, slot_id, and selected_slot_mapping when template active"
+```
+
+---
+
+## Task 5: Push branch and open PR
+
+- [ ] **Step 1: Run all tests one final time**
+
+```bash
+cd services/agent-collective-v2
+.venv/bin/pytest tests/test_template_catalog.py -v
+```
+
+Expected: 6 tests passing.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push origin feat/template-stamper-integration
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create \
+  --title "feat: veo_shorts_v1 template integration in agent collective" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `TEMPLATE_CATALOG` in `agent.py` mapping Shorts Creation Tool names to Remotion template schemas
+- `creative_phase` callback detects Photo to Video and writes `template_schema` to session state
+- `creative_director` generates 9 camera roll photos (up from 6) and marks 2 as selected inputs when template is active
+- `creative_presenter` surfaces the template name at the top of the storyboard presentation
+- `creative_prompter` embeds `template_id`, `slot_id` per job, and `selected_slot_mapping` in the generation manifest — additive, non-breaking for non-template runs
+
+## Related
+
+- Creative generator changes to consume slot IDs and produce template stamper handoff: #17
+
+## Test plan
+
+- [ ] Run `pytest tests/test_template_catalog.py -v` — 6 tests pass
+- [ ] Run a Photo to Video campaign end-to-end via `adk web` — storyboard presentation opens with template name, manifest includes slot IDs
+- [ ] Run a non-Photo-to-Video campaign — manifest identical to pre-change format (no template fields)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-06-template-integration-design.md
+++ b/docs/superpowers/specs/2026-05-06-template-integration-design.md
@@ -1,0 +1,105 @@
+# Template Integration in Agent Collective
+
+**Date:** 2026-05-06
+**Status:** Approved
+
+## Problem
+
+The template stamper renders final Shorts videos using Remotion templates with named asset slots. The creative generator (downstream of agent collective) needs to know which generated asset maps to which slot. Currently the `generation_manifest` produced by agent collective has no template awareness — slot mapping is implicit and would require guesswork in the creative generator.
+
+Additionally, at the storyboarding phase, the user has no visibility that their concept will be produced via a specific template with a fixed structure.
+
+## Scope
+
+Agent collective changes only. Creative generator changes to consume the new manifest fields and produce the template stamper handoff are tracked in [issue #17](https://github.com/ivanivanho-work/v3-creative-engine/issues/17).
+
+## Design
+
+### Template catalog
+
+A `TEMPLATE_CATALOG` dict in `agent.py` maps Shorts Creation Tool feature names to their template schema. 1:1 mapping for now; extensible to 1:many later by making the value a list.
+
+```python
+TEMPLATE_CATALOG = {
+    "Photo to Video": {
+        "template_id": "veo_shorts_v1",
+        "template_version": "1.0",
+        "selected_image_count": 2,
+        "has_generated_video": True,
+        "has_prompt_text": True,
+    }
+}
+```
+
+**Trigger rule:** whenever `marketing_brief.proposition.featured_tool.feature_name` matches a catalog key, the template is active. No opt-out. For Photo to Video this always maps to `veo_shorts_v1`.
+
+### Session state
+
+A `before_agent_callback` on `creative_phase` reads `marketing_brief` from session state, extracts `featured_tool.feature_name`, looks it up in `TEMPLATE_CATALOG`, and writes the result as `template_schema` to session state. If no match, writes `None`. All downstream prompt conditionals gate on this key.
+
+### Global default change: camera roll photo count 6 → 9
+
+The `creative_director.md` prompt currently hardcodes "camera roll scenes always use exactly 6 nested images." This changes to **9** unconditionally. This aligns the default with the `veo_shorts_v1` slot count and prevents drift for all future concepts regardless of template.
+
+### `creative_director.md` additions
+
+New section active when `template_schema` is present in session state:
+
+- Generate exactly 9 `ui_nested_asset` elements in the camera roll scene (already the new default — this section reinforces it)
+- Select `template_schema.selected_image_count` (2) of the 9 photos as the hero inputs to the AI video generation. Selection must be creatively motivated: which photos would produce the most compelling transformation? Mark each selected photo with `"selected": true` and a `"selection_rationale"` string explaining the creative choice.
+- The `promptText` (what the user typed into Photo to Video) is a `text_overlay` element in the UI scene. Write creative direction for what that prompt should convey — the actual copy is written by the creative_prompter.
+
+### `creative_presenter.md` addition
+
+When `template_schema` is present, prepend one line to the storyboard presentation:
+
+> "This concept will be produced using the **veo_shorts_v1** template."
+
+### `creative_prompter.md` additions
+
+When `template_schema` is present:
+
+**Manifest top level** — add two new fields:
+```json
+{
+  "template_id": "veo_shorts_v1",
+  "template_version": "1.0"
+}
+```
+
+**Per job** — add `slot_id` field (null for non-template runs):
+- Camera roll photos (`ui_nested_asset` elements): assigned `gridImage1` through `gridImage9` in order
+- Veo payoff video (climax scene): `generatedVideo`
+- End card video: locked asset, no generation job, no slot_id needed
+- All other jobs: `slot_id: null`
+
+**New top-level manifest block** — `selected_slot_mapping`:
+```json
+"selected_slot_mapping": {
+  "selectedImage1": "job_003",
+  "selectedImage2": "job_007"
+}
+```
+Points to the job IDs of the 2 selected photos. The creative generator reads this to know which generated file URLs to use for `selectedImage1/2` in the stamper handoff. The selected images are a subset of the grid images — no additional generation needed.
+
+**`promptText`** flows through `text_items` as `purpose: "in_ui_prompt_text"` — no change.
+
+### Generation manifest schema changes (additive, non-breaking)
+
+New optional fields — absent (or null) on non-template runs:
+
+| Location | Field | Type |
+|---|---|---|
+| Top level | `template_id` | `string \| null` |
+| Top level | `template_version` | `string \| null` |
+| Top level | `selected_slot_mapping` | `object \| null` |
+| Per job | `slot_id` | `string \| null` |
+
+Non-template campaigns produce manifests identical to today. The creative generator's existing intake is unaffected until it is updated per issue #17.
+
+## What is not changing
+
+- Generation manifest format (extended, not replaced)
+- Creative generator intake (reads the same `generation_manifest` key)
+- Non-Photo-to-Video campaign paths
+- Quality loop, adaptation pipeline, full campaign pipeline

--- a/services/agent-collective-v2/agent_collective/agent.py
+++ b/services/agent-collective-v2/agent_collective/agent.py
@@ -57,6 +57,23 @@ MARKET_OUTPUT_DIR = OUTPUT_DIR / MARKET
 KB_CACHE_DIR = OUTPUT_DIR / "kb_cache"
 
 
+# =========================================================================
+# Template catalog
+# =========================================================================
+# Maps Shorts Creation Tool feature_name → Remotion template schema.
+# 1:1 for now. Extend to a list per key when multiple templates exist per tool.
+
+TEMPLATE_CATALOG: dict[str, dict] = {
+    "Photo to Video": {
+        "template_id": "veo_shorts_v1",
+        "template_version": "1.0",
+        "selected_image_count": 2,
+        "has_generated_video": True,
+        "has_prompt_text": True,
+    },
+}
+
+
 def _get_kb_dirs(market: str) -> list[Path]:
     """Return the ordered list of KB folders for a given market.
 
@@ -575,6 +592,32 @@ def _make_timing_before_callback(agent_name: str):
     """Factory: before_agent_callback that records when an agent starts."""
     async def callback(callback_context):
         _record_agent_start(callback_context.session.id, agent_name)
+    return callback
+
+
+def _make_creative_phase_before_callback():
+    """Before-callback for creative_phase.
+
+    Reads marketing_brief from session state, looks up the featured tool in
+    TEMPLATE_CATALOG, and writes the matching template schema (or None) as
+    template_schema to session state. All downstream prompt conditionals gate
+    on this key.
+    """
+    async def callback(callback_context) -> None:
+        brief_raw = callback_context.state.get("marketing_brief")
+        if not brief_raw:
+            callback_context.state["template_schema"] = None
+            return
+        brief = _parse_state_value(brief_raw)
+        feature_name = (
+            brief.get("proposition", {})
+                 .get("featured_tool", {})
+                 .get("feature_name", "")
+        ) or ""
+        template = TEMPLATE_CATALOG.get(feature_name)
+        callback_context.state["template_schema"] = (
+            json.dumps(template) if template else None
+        )
     return callback
 
 
@@ -2036,6 +2079,7 @@ creative_presenter = LlmAgent(
 creative_phase = SequentialAgent(
     name="creative_phase",
     sub_agents=[creative_director, creative_presenter],
+    before_agent_callback=_make_creative_phase_before_callback(),
 )
 
 

--- a/services/agent-collective-v2/agent_collective/agent.py
+++ b/services/agent-collective-v2/agent_collective/agent.py
@@ -609,6 +609,9 @@ def _make_creative_phase_before_callback():
             callback_context.state["template_schema"] = None
             return
         brief = _parse_state_value(brief_raw)
+        if not isinstance(brief, dict):
+            callback_context.state["template_schema"] = None
+            return
         feature_name = (
             brief.get("proposition", {})
                  .get("featured_tool", {})

--- a/services/agent-collective-v2/agent_collective/prompts/creative/creative_director.md
+++ b/services/agent-collective-v2/agent_collective/prompts/creative/creative_director.md
@@ -162,7 +162,9 @@ Reference the featured tool using the exact `feature_name` from `marketing_brief
               "element_type": "character | prop | environment | ui_nested_asset | text_overlay",
               "description": "string - what this element is and does in the scene",
               "creative_direction": "string | null - only for scene-specific elements not in recurring_elements",
-              "recurring_element_ref": "string | null - references a recurring_elements.element_id if applicable"
+              "recurring_element_ref": "string | null - references a recurring_elements.element_id if applicable",
+              "selected": "boolean | omitted - true only for template-selected camera roll photos (ui_nested_asset)",
+              "selection_rationale": "string | omitted - only on selected photos when template_schema is active"
             }
           ],
           "ui_context": {
@@ -233,7 +235,7 @@ If `template_schema` is not null, parse it and apply these additional rules:
 
 ### Selected photos (Photo to Video template)
 
-When `template_schema.selected_image_count` is present (value: 2), you must designate exactly that many of the 9 camera roll photos as the **selected inputs** for AI video generation. The selection must be creatively motivated: choose the photos whose subjects would produce the most compelling and narratively coherent transformation.
+When `template_schema.selected_image_count` is present, you must designate exactly that many of the 9 camera roll photos as the **selected inputs** for AI video generation. The selection must be creatively motivated: choose the photos whose subjects would produce the most compelling and narratively coherent transformation.
 
 For each selected photo element, add two extra fields alongside the existing ones:
 
@@ -262,6 +264,7 @@ You are a specialist agent in an automated pipeline. You are NOT talking to a us
 
 **State reads:**
 - `marketing_brief` - The complete marketing brief. Read all sections: campaign_context, audience, proposition, creative_guardrails, deliverables, and ad_copy_constraints.
+- `template_schema` - Remotion template schema if the active featured tool maps to a template, else null. Set by the creative_phase before-callback.
 
 **State writes:**
 - Your output is stored as `creative_package`.
@@ -286,3 +289,6 @@ The values below are injected from session state. Use them as your primary input
 
 ### marketing_brief
 {marketing_brief}
+
+### template_schema
+{template_schema}

--- a/services/agent-collective-v2/agent_collective/prompts/creative/creative_director.md
+++ b/services/agent-collective-v2/agent_collective/prompts/creative/creative_director.md
@@ -169,7 +169,7 @@ Reference the featured tool using the exact `feature_name` from `marketing_brief
             "shows_product_ui": false,
             "ui_description": "string | null - e.g. YouTube Shorts camera roll selection screen",
             "nested_assets_to_generate": [
-              "string | null - camera roll scenes always list exactly 6 photos (camera_roll_photo_01 through camera_roll_photo_06)"
+              "string | null - camera roll scenes always list exactly 9 photos (camera_roll_photo_01 through camera_roll_photo_09)"
             ],
             "ui_note": "UI frame itself is NOT generated. Only the nested assets within it."
           }
@@ -219,9 +219,38 @@ Reference the featured tool using the exact `feature_name` from `marketing_brief
 - **Do not generate product UI.** When a scene includes a phone screen or app interface, the UI frame is a locked screenshot or template. Only the assets nested within the UI (photos, videos, generated content visible on screen) are generation targets.
 - **Do not design reaction or resolution scenes that feature a phone as a physical prop.** Showing a user holding a phone after watching the generated output is high-risk for generation failure -- models default to rendering a visible screen regardless of framing instructions. Convey emotional satisfaction through hand gestures or body posture alone: hands pressing gently against the chest, hands resting in a pleased gesture, or a body language cue that implies delight without any phone in frame.
 - **Do not design a scene where the AI-generated output video plays on a held phone.** The payoff video (the AI-generated transformation output) must appear as its own standalone fullscreen scene. It may never appear on a phone screen being held in someone's hand or viewed from a POV perspective. Generative models cannot reproduce the same generated video content at a reduced scale inside a new scene, so this type of shot will never match the actual payoff output and must not be designed.
-- **Do not bundle nested assets into a single element.** When a scene shows multiple individual assets within a UI frame, list each one as a separate element with its own `element_id`, description, and creative direction. The Creative Prompter generates one prompt per element, and collage-style multi-image generation is unreliable. **Camera roll scenes always use exactly 6 nested images** (`camera_roll_photo_01` through `camera_roll_photo_06`) to match the locked UI template. List all 6 individually so each gets its own generation job. Do not use a different count.
+- **Do not bundle nested assets into a single element.** When a scene shows multiple individual assets within a UI frame, list each one as a separate element with its own `element_id`, description, and creative direction. The Creative Prompter generates one prompt per element, and collage-style multi-image generation is unreliable. **Camera roll scenes always use exactly 9 nested images** (`camera_roll_photo_01` through `camera_roll_photo_09`) to match the locked UI template. List all 9 individually so each gets its own generation job. Do not use a different count.
 - **Do not rename or paraphrase feature names.** Use the exact `feature_name` from the marketing brief.
 - **Do not ignore the design target.** The creative should resonate with the full design target from the brief (e.g., MF 18-44), not just one gender subset. If the theme skews naturally toward one gender, ensure the visual elements, settings, and scenarios still feel inclusive.
+
+## Template-aware storyboarding
+
+The session state key `template_schema` tells you whether the selected concept maps to a Remotion template. Check its value before designing the storyboard.
+
+Current value: `{template_schema}`
+
+If `template_schema` is not null, parse it and apply these additional rules:
+
+### Selected photos (Photo to Video template)
+
+When `template_schema.selected_image_count` is present (value: 2), you must designate exactly that many of the 9 camera roll photos as the **selected inputs** for AI video generation. The selection must be creatively motivated: choose the photos whose subjects would produce the most compelling and narratively coherent transformation.
+
+For each selected photo element, add two extra fields alongside the existing ones:
+
+```json
+{
+  "element_id": "camera_roll_photo_03",
+  "element_type": "ui_nested_asset",
+  "description": "...",
+  "creative_direction": "...",
+  "selected": true,
+  "selection_rationale": "This photo's subject — [brief reason] — will produce the strongest transformation payoff."
+}
+```
+
+Non-selected photos omit `selected` and `selection_rationale` entirely (do not set `selected: false`).
+
+The selection rationale is read by the creative_presenter to explain to the user why these two photos anchor the video generation.
 
 ---
 

--- a/services/agent-collective-v2/agent_collective/prompts/creative/creative_presenter.md
+++ b/services/agent-collective-v2/agent_collective/prompts/creative/creative_presenter.md
@@ -14,9 +14,15 @@ You read from one session state key:
 
 Present the creative package in a single response. Your presentation must follow this structure:
 
-### 1. Opening context (one line)
+### 1. Opening context
 
-Open with a brief line that frames what the user is about to see. Reference the campaign name if available from the brief_id or concept names. Do not say "I analyzed" or "I developed" since upstream agents did the creative work. Keep it simple, e.g., "Here are the creative concepts for the Korea campaign, ready for your review."
+If `template_schema` is not null (current value: `{template_schema}`), open with exactly this line before anything else:
+
+> "This concept will be produced using the **[template_schema.template_id]** template."
+
+Then on the next line, add the standard one-line campaign context (e.g., "Here are the creative concepts for the Korea campaign, ready for your review.").
+
+If `template_schema` is null, open with the standard one-line campaign context only.
 
 ### 2. Video storyboard (for each shorts_featured_video concept)
 
@@ -95,6 +101,7 @@ You are a presenter agent. Your response goes directly to the user in the chat.
 
 **State reads:**
 - `creative_package` - The creative concepts to present.
+- `template_schema` - Remotion template schema if the active featured tool maps to a template, else null.
 
 **State writes:**
 - Nothing. Your response goes to the user, not to state.
@@ -116,3 +123,6 @@ The values below are injected from session state. Use them as your primary input
 
 ### creative_package
 {creative_package}
+
+### template_schema
+{template_schema}

--- a/services/agent-collective-v2/agent_collective/prompts/production/creative_prompter.md
+++ b/services/agent-collective-v2/agent_collective/prompts/production/creative_prompter.md
@@ -156,6 +156,8 @@ Reference the featured tool using the exact `feature_name` from `marketing_brief
   "market": "string - country code from marketing_brief.market.country_code",
   "market_nationality": "string - carried from marketing_brief.market.market_nationality",
   "created_at": "ISO 8601 timestamp",
+  "template_id": "string | null - template identifier when template active, else omit",
+  "template_version": "string | null - e.g. 1.0 when template active, else omit",
   "total_reference_images": 0,
   "total_jobs": 0,
   "total_text_items": 0,
@@ -181,6 +183,7 @@ Reference the featured tool using the exact `feature_name` from `marketing_brief
   "jobs": [
     {
       "job_id": "string - e.g. job_001",
+      "slot_id": "string | null - e.g. gridImage1, generatedVideo, or null",
       "deliverable_id": "string - e.g. V1 or S1",
       "scene_id": "string - e.g. scene_01",
       "element_id": "string - e.g. nested_01",
@@ -201,6 +204,10 @@ Reference the featured tool using the exact `feature_name` from `marketing_brief
       "status": "pending"
     }
   ],
+  "selected_slot_mapping": {
+    "selectedImage1": "string | null - job_id of first selected camera roll photo, null if no template",
+    "selectedImage2": "string | null - job_id of second selected camera roll photo, null if no template"
+  },
   "text_items": [
     {
       "deliverable_id": "string - e.g. V1",
@@ -215,6 +222,49 @@ Reference the featured tool using the exact `feature_name` from `marketing_brief
   ]
 }
 ```
+
+## Template-aware manifest generation
+
+The session state key `template_schema` tells you whether this run maps to a Remotion template.
+
+Current value: `{template_schema}`
+
+If `template_schema` is not null, apply these additional rules when building the manifest:
+
+### Top-level template fields
+
+Add two fields at the root of the manifest object:
+
+```json
+{
+  "template_id": "<template_schema.template_id>",
+  "template_version": "<template_schema.template_version>",
+  ...
+}
+```
+
+### slot_id per job
+
+For every job, add a `slot_id` field. Set it according to these rules:
+
+- **Camera roll photos** (`element_type: "ui_nested_asset"`, `element_id` matching `camera_roll_photo_01` through `camera_roll_photo_09`): assign `slot_id` values `gridImage1` through `gridImage9` in the same order (photo_01 → gridImage1, photo_02 → gridImage2, … photo_09 → gridImage9).
+- **Veo payoff video** (the climax scene's video job, `asset_type: "video"` from a `hook`/`body`/`climax`/`resolution` scene that is not a camera roll photo): assign `slot_id: "generatedVideo"`.
+- **All other jobs**: assign `slot_id: null`.
+
+### selected_slot_mapping
+
+After the `jobs` array, add a `selected_slot_mapping` object. Read the creative_package storyboard and find the camera roll photos that have `"selected": true`. Map their template slot IDs to their job IDs:
+
+```json
+"selected_slot_mapping": {
+  "selectedImage1": "job_003",
+  "selectedImage2": "job_007"
+}
+```
+
+Where `job_003` and `job_007` are the `job_id` values of the selected camera roll photo jobs. The order matches the order the selected photos appear in the storyboard element list.
+
+If `template_schema` is null, omit `template_id`, `template_version`, and `selected_slot_mapping` from the manifest entirely, and set `slot_id: null` on all jobs.
 
 ## What to avoid
 
@@ -245,6 +295,7 @@ You are a specialist agent in an automated pipeline. You are NOT talking to a us
 **State reads:**
 - `creative_package` - The Creative Director's storyboard concepts, recurring elements, and policy compliance
 - `marketing_brief` - Audience context, featured tool details, ad copy constraints, brand voice, creative guardrails
+- `template_schema` - Remotion template schema if the active featured tool maps to a template, else null
 
 **State writes:**
 - Your output is stored as `generation_manifest`.
@@ -274,3 +325,6 @@ The values below are injected from session state. Use them as your primary input
 
 ### marketing_brief
 {marketing_brief}
+
+### template_schema
+{template_schema}

--- a/services/agent-collective-v2/tests/test_template_catalog.py
+++ b/services/agent-collective-v2/tests/test_template_catalog.py
@@ -88,3 +88,11 @@ async def test_callback_handles_missing_brief_gracefully():
     cb = _make_creative_phase_before_callback()
     await cb(ctx)  # must not raise
     assert ctx.state.get("template_schema") is None
+
+
+@pytest.mark.asyncio
+async def test_callback_handles_malformed_brief_gracefully():
+    ctx = _FakeCallbackContext({"marketing_brief": "not valid json"})
+    cb = _make_creative_phase_before_callback()
+    await cb(ctx)  # must not raise
+    assert ctx.state.get("template_schema") is None

--- a/services/agent-collective-v2/tests/test_template_catalog.py
+++ b/services/agent-collective-v2/tests/test_template_catalog.py
@@ -1,0 +1,90 @@
+import json
+import pytest
+import sys
+from pathlib import Path
+
+# Allow importing agent_collective without a full ADK environment
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so agent.py can be imported without google-adk installed
+# in the test environment. If google-adk IS installed these are ignored.
+# ---------------------------------------------------------------------------
+try:
+    from agent_collective.agent import TEMPLATE_CATALOG, _make_creative_phase_before_callback
+except ImportError:
+    pytest.skip("google-adk not available", allow_module_level=True)
+
+
+class _FakeState(dict):
+    pass
+
+
+class _FakeSession:
+    id = "test-session"
+
+
+class _FakeCallbackContext:
+    def __init__(self, state: dict):
+        self.state = _FakeState(state)
+        self.session = _FakeSession()
+
+
+# ---------------------------------------------------------------------------
+# TEMPLATE_CATALOG tests
+# ---------------------------------------------------------------------------
+
+def test_catalog_has_photo_to_video():
+    assert "Photo to Video" in TEMPLATE_CATALOG
+
+
+def test_photo_to_video_maps_to_veo_shorts_v1():
+    entry = TEMPLATE_CATALOG["Photo to Video"]
+    assert entry["template_id"] == "veo_shorts_v1"
+    assert entry["template_version"] == "1.0"
+
+
+def test_photo_to_video_has_selected_image_count_2():
+    assert TEMPLATE_CATALOG["Photo to Video"]["selected_image_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _make_creative_phase_before_callback tests
+# ---------------------------------------------------------------------------
+
+def _make_brief(feature_name: str) -> str:
+    return json.dumps({
+        "proposition": {
+            "featured_tool": {
+                "feature_name": feature_name
+            }
+        }
+    })
+
+
+@pytest.mark.asyncio
+async def test_callback_writes_template_schema_for_photo_to_video():
+    ctx = _FakeCallbackContext({"marketing_brief": _make_brief("Photo to Video")})
+    cb = _make_creative_phase_before_callback()
+    await cb(ctx)
+    assert ctx.state.get("template_schema") is not None
+    schema = json.loads(ctx.state["template_schema"])
+    assert schema["template_id"] == "veo_shorts_v1"
+    assert schema["selected_image_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_callback_writes_none_for_unknown_tool():
+    ctx = _FakeCallbackContext({"marketing_brief": _make_brief("Add Audio")})
+    cb = _make_creative_phase_before_callback()
+    await cb(ctx)
+    assert ctx.state.get("template_schema") is None
+
+
+@pytest.mark.asyncio
+async def test_callback_handles_missing_brief_gracefully():
+    ctx = _FakeCallbackContext({})
+    cb = _make_creative_phase_before_callback()
+    await cb(ctx)  # must not raise
+    assert ctx.state.get("template_schema") is None


### PR DESCRIPTION
Summary: Adds TEMPLATE_CATALOG in agent.py mapping Shorts Creation Tool names to Remotion template schemas. creative_phase callback detects Photo to Video and writes template_schema to session state. creative_director generates 9 camera roll photos (up from 6) and marks 2 as selected inputs when template is active. creative_presenter surfaces the template name at the top of the storyboard presentation. creative_prompter embeds template_id, slot_id per job, and selected_slot_mapping in the generation manifest.

Test plan: Run pytest tests/test_template_catalog.py -v — 7 tests pass. Run a Photo to Video campaign end-to-end via adk web. Run a non-Photo-to-Video campaign to ensure manifest has no template fields.