### PR TITLE
shorts-intel-hub: fix uniform-score normalization to 50 instead of 100 (closes #12)

### DIFF
--- a/functions/src/shorts-intel-hub/processing/normalize.js
+++ b/functions/src/shorts-intel-hub/processing/normalize.js
@@ -32,7 +32,7 @@ function normalizeField(trends, field) {
     if (!t || t.hidden) continue;
     const v = t[field];
     if (typeof v !== 'number' || !Number.isFinite(v)) continue;
-    t[`${field}Normalized`] = span === 0 ? 100 : Math.round(((v - min) / span) * 1000) / 10;
+    t[`${field}Normalized`] = span === 0 ? 50 : Math.round(((v - min) / span) * 1000) / 10;
   }
 }
 


### PR DESCRIPTION
## Summary
- When all trends in a (market, week) cell share the same raw score, min-max normalization has `span=0` and was defaulting every trend to 100
- Changed default to 50 (midpoint) — no trend should appear as top-ranked when all are equal

## Root cause
`normalize.js:35` — `span === 0 ? 100` should be `span === 0 ? 50`

## Test plan
- [ ] Upload Nyan Cat dataset with 2026-W11 data — trends should show score ~50 instead of 100
- [ ] Weeks with varied scores still normalize correctly (0–100 range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)