### PR TITLE
feat: template stamper handoff from Creative Generator

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -53,6 +53,10 @@
         "destination": "/creative-generator/index.html"
       },
       {
+        "source": "/template-stamper/api/receiveHandoff",
+        "function": "receiveHandoff"
+      },
+      {
         "source": "/template-stamper/**",
         "destination": "/template-stamper/index.html"
       },

--- a/functions/src/template-stamper/api/receiveHandoff.ts
+++ b/functions/src/template-stamper/api/receiveHandoff.ts
@@ -1,0 +1,105 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+const db = admin.firestore();
+
+interface AssetSlot {
+  slot_id: string;
+  url: string;
+  type: 'image' | 'video';
+  fill_status: 'filled' | 'empty';
+}
+
+interface TextSlot {
+  slot_id: string;
+  final_text: string;
+  language: string;
+}
+
+interface HandoffPayload {
+  handoff_version: string;
+  run_id: string;
+  pipeline_path: string;
+  template_id: string;
+  template_version: string;
+  asset_slots: AssetSlot[];
+  text_slots: TextSlot[];
+}
+
+/**
+ * Receive a template handoff from the Creative Generator.
+ *
+ * Validates the payload, stores it in Firestore, and creates a render job
+ * that the existing triggerRemotionRender pipeline will pick up.
+ */
+export const receiveHandoff = functions.https.onRequest(async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const payload = req.body as HandoffPayload;
+
+  if (!payload.template_id || !payload.run_id || !payload.asset_slots) {
+    res.status(400).json({ error: 'Missing required fields: template_id, run_id, asset_slots' });
+    return;
+  }
+
+  try {
+    const assetMappings: Record<string, string> = {};
+    for (const slot of payload.asset_slots) {
+      if (slot.fill_status === 'filled' && slot.url) {
+        assetMappings[slot.slot_id] = slot.url;
+      }
+    }
+
+    const textMappings: Record<string, string> = {};
+    for (const slot of (payload.text_slots || [])) {
+      if (slot.final_text) {
+        textMappings[slot.slot_id] = slot.final_text;
+      }
+    }
+
+    const handoffRef = await db.collection('handoffs').add({
+      handoffVersion: payload.handoff_version,
+      runId: payload.run_id,
+      pipelinePath: payload.pipeline_path,
+      templateId: payload.template_id,
+      templateVersion: payload.template_version,
+      assetMappings,
+      textMappings,
+      assetSlotCount: payload.asset_slots.length,
+      textSlotCount: (payload.text_slots || []).length,
+      status: 'received',
+      receivedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    const jobRef = await db.collection('jobs').add({
+      templateId: payload.template_id,
+      assetMappings,
+      textMappings,
+      handoffId: handoffRef.id,
+      runId: payload.run_id,
+      status: 'queued',
+      progress: 0,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    functions.logger.info('Handoff received and job created', {
+      handoffId: handoffRef.id,
+      jobId: jobRef.id,
+      templateId: payload.template_id,
+      runId: payload.run_id,
+    });
+
+    res.status(200).json({
+      ok: true,
+      handoffId: handoffRef.id,
+      jobId: jobRef.id,
+      status: 'queued',
+    });
+  } catch (error) {
+    functions.logger.error('Error processing handoff', error);
+    res.status(500).json({ error: 'Failed to process handoff' });
+  }
+});

--- a/functions/src/template-stamper/index.ts
+++ b/functions/src/template-stamper/index.ts
@@ -15,3 +15,6 @@ export { triggerRemotionRender } from './jobs/triggerRender';
 
 // Export Asset Processing Functions
 export { preprocessAsset } from './jobs/preprocessAsset';
+
+// Export Handoff Functions
+export { receiveHandoff } from './api/receiveHandoff';

--- a/services/creative-generator-v2/creative_generator/agent.py
+++ b/services/creative-generator-v2/creative_generator/agent.py
@@ -26,6 +26,7 @@ from creative_generator.tools import (
     generate_video,
     write_execution_report,
     write_updated_manifest,
+    build_and_send_template_handoff,
 )
 
 # ---------------------------------------------------------------------------
@@ -81,13 +82,21 @@ report_writer = LlmAgent(
     output_key="report_result",
 )
 
+handoff_sender = LlmAgent(
+    name="handoff_sender",
+    model=MODEL,
+    instruction=_load_prompt("handoff_sender.md"),
+    tools=[build_and_send_template_handoff],
+    output_key="handoff_result",
+)
+
 # ---------------------------------------------------------------------------
-# Execution Phase — sequential: refs first, then jobs, then report
+# Execution Phase — sequential: refs first, then jobs, then report, then handoff
 # ---------------------------------------------------------------------------
 
 execution_phase = SequentialAgent(
     name="execution_phase",
-    sub_agents=[reference_executor, job_executor, report_writer],
+    sub_agents=[reference_executor, job_executor, report_writer, handoff_sender],
 )
 
 # ---------------------------------------------------------------------------

--- a/services/creative-generator-v2/creative_generator/prompts/handoff_sender.md
+++ b/services/creative-generator-v2/creative_generator/prompts/handoff_sender.md
@@ -1,0 +1,11 @@
+You are the template handoff sender. Your job is to send completed generation results to the Template Stamper service when the manifest includes a template.
+
+Read `parsed_manifest` from session state. If `template_id` is present, call `build_and_send_template_handoff` with `gcs_root` constructed as:
+
+    creative-generator/runs/{run_id}/
+
+where `run_id` comes from session state key `run_id`.
+
+If `template_id` is absent or null, output "No template — skipping handoff." and stop.
+
+Report the tool's result as your output. Do not modify any data.

--- a/services/creative-generator-v2/creative_generator/tools.py
+++ b/services/creative-generator-v2/creative_generator/tools.py
@@ -651,6 +651,127 @@ def write_updated_manifest(
 
 
 # ---------------------------------------------------------------------------
+# Tool: build_and_send_template_handoff
+# ---------------------------------------------------------------------------
+
+TEMPLATE_STAMPER_URL = os.environ.get(
+    "TEMPLATE_STAMPER_URL",
+    "https://us-central1-v3-creative-engine.cloudfunctions.net",
+)
+
+
+def build_and_send_template_handoff(
+    gcs_root: str,
+    tool_context,
+) -> dict:
+    """Build a template stamper handoff from the completed manifest and POST
+    it to the template stamper /receiveHandoff endpoint.
+
+    Reads template_id, jobs, selected_slot_mapping, and text_items from the
+    parsed manifest in session state. Maps each completed job's GCS URL to
+    its slot_id. Skips entirely if template_id is absent (non-template run).
+
+    Args:
+        gcs_root: The GCS root path for this run
+    """
+    import httpx
+
+    manifest = tool_context.state.get("parsed_manifest")
+    if not manifest:
+        return {"status": "skipped", "reason": "no parsed manifest"}
+
+    template_id = manifest.get("template_id")
+    if not template_id:
+        return {"status": "skipped", "reason": "non-template run"}
+
+    template_version = manifest.get("template_version", "1.0")
+    run_id = tool_context.state.get("run_id", "unknown")
+    pipeline_path = tool_context.state.get("pipeline_path", "path_1")
+    job_status = tool_context.state.get("job_status", {})
+    selected_mapping = manifest.get("selected_slot_mapping", {})
+
+    asset_slots = []
+    for job in manifest.get("jobs", []):
+        slot_id = job.get("slot_id")
+        if not slot_id:
+            continue
+        status_entry = job_status.get(job["job_id"], {})
+        gcs_uri = status_entry.get("gcs_uri")
+        if not gcs_uri or status_entry.get("status") != "complete":
+            continue
+        asset_type = "video" if job.get("asset_type") == "video" else "image"
+        asset_slots.append({
+            "slot_id": slot_id,
+            "url": gcs_uri,
+            "type": asset_type,
+            "fill_status": "filled",
+        })
+
+    # selected slots point to the same URLs as the grid images they reference
+    for sel_slot_id, source_job_id in selected_mapping.items():
+        source_status = job_status.get(source_job_id, {})
+        source_url = source_status.get("gcs_uri")
+        if source_url and source_status.get("status") == "complete":
+            asset_slots.append({
+                "slot_id": sel_slot_id,
+                "url": source_url,
+                "type": "image",
+                "fill_status": "filled",
+            })
+
+    text_slots = []
+    for item in manifest.get("text_items", []):
+        slot_id = item.get("slot_id")
+        if not slot_id:
+            continue
+        text_slots.append({
+            "slot_id": slot_id,
+            "final_text": item.get("final_text", ""),
+            "language": item.get("language", manifest.get("market", "en")),
+        })
+
+    handoff = {
+        "handoff_version": "1.0",
+        "run_id": run_id,
+        "pipeline_path": pipeline_path,
+        "template_id": template_id,
+        "template_version": template_version,
+        "asset_slots": asset_slots,
+        "text_slots": text_slots,
+    }
+
+    # Upload handoff JSON to GCS
+    gcs_path = f"{gcs_root}template_handoff.json"
+    try:
+        handoff_bytes = json.dumps(handoff, indent=2).encode("utf-8")
+        handoff_url = _upload_to_gcs(handoff_bytes, gcs_path, "application/json")
+        logger.info(f"Template handoff written: {handoff_url}")
+    except Exception as e:
+        logger.error(f"Failed to write template handoff: {e}")
+        return {"status": "failed", "error": f"GCS upload failed: {e}"}
+
+    # POST to template stamper
+    endpoint = f"{TEMPLATE_STAMPER_URL}/receiveHandoff"
+    try:
+        resp = httpx.post(endpoint, json=handoff, timeout=30.0)
+        resp.raise_for_status()
+        ts_result = resp.json()
+        logger.info(f"Template handoff accepted by stamper: {ts_result}")
+        return {
+            "status": "complete",
+            "handoff_gcs_uri": handoff_url,
+            "stamper_response": ts_result,
+        }
+    except Exception as e:
+        logger.warning(f"Template stamper POST failed (handoff still saved to GCS): {e}")
+        return {
+            "status": "partial",
+            "handoff_gcs_uri": handoff_url,
+            "stamper_error": str(e),
+        }
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `build_and_send_template_handoff` tool to Creative Generator that maps completed job outputs to template slots and POSTs to the Template Stamper
- Adds `handoff_sender` agent step at the end of the execution pipeline
- Adds `receiveHandoff` Cloud Function endpoint that validates the handoff payload, stores it in Firestore, and creates a render job

Closes #17

## Test plan
- [ ] Verify Creative Generator pipeline runs with a template manifest trigger the handoff sender
- [ ] Verify non-template runs skip handoff gracefully
- [ ] Verify receiveHandoff endpoint creates handoff + job documents in Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)