### PR TITLE
fix(shorts-brain): allow shortsbrain_data so memory persists

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -94,6 +94,13 @@ service cloud.firestore {
       allow write: if authed();
     }
 
+    // Auto-restore store: the analyzed dataset (shortsbrain_data/latest +
+    // chunk_* docs) the app reloads on open so work survives exit/re-entry.
+    match /shortsbrain_data/{docId} {
+      allow read: if authed();
+      allow write: if authed();
+    }
+
     match /artifacts/{appId}/public/data/{collection}/{document=**} {
       allow read: if authed();
       allow write: if authed();


### PR DESCRIPTION
## Summary

Restores stateful memory — the app's analyzed dataset now survives exiting and re-entering.

**Root cause:** The app already has the full feature in code — on analysis it writes the dataset to Firestore (`shortsbrain_data/latest` + `chunk_*` docs), and on open an `onSnapshot` listener reloads it. But `firestore.rules` has **no rule for the `shortsbrain_data` collection**, so every read/write fell through to the catch-all `allow read, write: if false`. The save failed silently and the auto-restore listener got permission-denied — so re-entering the app always showed an empty state.

(The named-snapshot history under `artifacts/{appId}/public/data/snapshots` has its own existing rule, so the sidebar snapshot list was unaffected — only the auto-restore was broken.)

**Fix:** Add a `shortsbrain_data` rule gated on the same `authed()` allowlist as the sibling `shorts_brain_snapshots` / `analysis_results` Shorts Brain collections. No app code change needed — the persistence logic was correct, just blocked.

Merging to `main` triggers `deploy-rules.yml`, which deploys the updated Firestore rules.

## Test plan

- [ ] `deploy-rules.yml` runs and deploys rules on merge
- [ ] Upload + analyze files, then reload the app → analyzed OKR data is restored automatically
- [ ] Exit the app entirely and re-enter → data still there
- [ ] No `permission-denied` / "Firestore Error" in the browser console
- [ ] Saved snapshots still appear and load from the sidebar

https://claude.ai/code/session_01DfCF5d5hSYbrLqgSKq3jLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfCF5d5hSYbrLqgSKq3jLh)_