### PR TITLE
chore(agent-collective): update test models to gemini-3.5-flash

### DIFF
--- a/services/agent-collective-v2/agent_collective/agent.py
+++ b/services/agent-collective-v2/agent_collective/agent.py
@@ -32,8 +32,8 @@ from google.genai import types
 
 # Both set to Flash for cost-effective testing (~$0.15/run).
 # Change MODEL_PRO to "gemini-2.5-pro" for production quality.
-MODEL_FLASH = "gemini-2.5-flash"
-MODEL_PRO = "gemini-2.5-flash"
+MODEL_FLASH = "gemini-3.5-flash"
+MODEL_PRO = "gemini-3.5-flash"
 
 # Paths (relative to this file)
 BASE_DIR = Path(__file__).parent


### PR DESCRIPTION
## Summary

Closes #38. Bumps the agent-collective test models from `gemini-2.5-flash` to `gemini-3.5-flash`.

`gemini-3.5-flash` went GA on 2026-05-19 (model ID `gemini-3.5-flash`) and is stable for production use — verified against Google's official Gemini API model docs.

Both `MODEL_FLASH` and `MODEL_PRO` in `services/agent-collective-v2/agent_collective/agent.py` are updated, preserving the existing "both on Flash for cost-effective testing" setup. The issue's optional suggestion of `gemini-3.1-pro-preview` for `MODEL_PRO` was **not** applied — it's a preview (non-GA) model; left for a separate decision.

## Test plan

- [ ] agent-collective test run succeeds against `gemini-3.5-flash`
- [ ] No model-not-found / invalid-model errors at runtime

https://claude.ai/code/session_01DfCF5d5hSYbrLqgSKq3jLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfCF5d5hSYbrLqgSKq3jLh)_