### PR TITLE
chore(rules): trigger CI deploy of Firestore rules (shortsbrain_data persistence)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,5 +1,8 @@
 rules_version = '2';
 
+// Deploy marker 2026-06-11: re-deploy via CI after deploy-rules.yml fix (#60) —
+// production rules predate the shortsbrain_data block, breaking Shorts Brain persistence.
+
 // Phase −1 lockdown: gate every read/write behind Firebase Auth allowlist.
 // allowlist = ivanho.wz@gmail.com OR @google.com.
 // Triggers (admin SDK) bypass rules — unaffected.


### PR DESCRIPTION
No-op comment change to `firestore.rules` to fire the paths-filtered `deploy-rules` workflow (manual `workflow_dispatch` is not accessible to this integration).

Production Firestore rules were never updated after #44 because every deploy-rules run aborted on the storage 403 — fixed in #60. Merging this finally ships the `shortsbrain_data` allow-block to production, which is what makes Shorts Brain persistence work.

https://claude.ai/code/session_01Peg2ddHKtZ66xpAw57uKPq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Peg2ddHKtZ66xpAw57uKPq)_